### PR TITLE
Change default region in helm values to westus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We provide a helm chart to help install the exporter. Note that this data export
 ```bash
 export WTUSERNAME=XXXX   # WattTime auth info.
 export WTPASSWORD=YYYY
-export REGION=eastus     # The region where the AKS cluster locates.
+export REGION=westus     # The region where the AKS cluster locates.
 
 helm install carbon-intensity-exporter \
    --set carbonDataExporter.region=$REGION \

--- a/charts/carbon-intensity-exporter/values.yaml
+++ b/charts/carbon-intensity-exporter/values.yaml
@@ -21,7 +21,7 @@ carbonDataExporter:
     tag: "0.1.0"
   configmapName: carbon-intensity
   patrolInterval: 12h
-  region: eastus
+  region: westus
 
 service:
   type: ClusterIP


### PR DESCRIPTION
See #23

Using `westus` as the region maps to the `CAISO_NORTH` grid region. WattTime kindly provide free access to forecast data for this region for evaluation purposes.