### PR TITLE
chore: update Carbon Aware SDK for WattTime API v3

### DIFF
--- a/charts/carbon-intensity-exporter/Chart.yaml
+++ b/charts/carbon-intensity-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: carbon-intensity-exporter
 description: A Helm chart for Kubernetes carbon-intensity-exporter
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/charts/carbon-intensity-exporter/templates/deployment.yaml
+++ b/charts/carbon-intensity-exporter/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                 name: {{ include "carbon-intensity-exporter.fullname" . }}
                 key: password
           {{- end }}
-          - name: LocationDataSourcesConfiguration__LocationSourceFiles__DataFileLocation
+          - name: LocationDataSourcesConfiguration__LocationSourceFiles__0__DataFileLocation
             value: {{ .Values.apiServer.dataFileLocation }}
           - name: Urls
             value: {{ .Values.apiServer.urls }}

--- a/charts/carbon-intensity-exporter/values.yaml
+++ b/charts/carbon-intensity-exporter/values.yaml
@@ -10,7 +10,7 @@ apiServer:
   image:
     repository: ghcr.io/azure/kubernetes-carbon-intensity-exporter/server
     pullPolicy: IfNotPresent
-    tag: "0.1.0"
+    tag: "0.4.0"
   dataFileLocation: azure-regions.json
   urls: http://0.0.0.0:7031;http://0.0.0.0:80;
 carbonDataExporter:
@@ -18,7 +18,7 @@ carbonDataExporter:
   image:
     repository: ghcr.io/azure/kubernetes-carbon-intensity-exporter/exporter
     pullPolicy: IfNotPresent
-    tag: "0.1.0"
+    tag: "0.4.0"
   configmapName: carbon-intensity
   patrolInterval: 12h
   region: westus
@@ -32,7 +32,7 @@ electricityMaps:
   baseURL: https://api.electricitymap.org/v3/
 
 wattTime:
-  baseURL: https://api2.watttime.org/v2/
+  baseURL: https://api.watttime.org/v3/
   username: username
   password: password
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,18 +1,20 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
+# Allows .NET tool targeting older versions run on latest major version
+ENV DOTNET_ROLL_FORWARD=LatestMajor
+
 # Copy everything from source
-RUN git clone https://github.com/Green-Software-Foundation/carbon-aware-sdk.git && cd carbon-aware-sdk
+RUN git clone https://github.com/Green-Software-Foundation/carbon-aware-sdk.git && cd carbon-aware-sdk && git checkout v1.7.0
 # Use implicit restore to build and publish
 RUN dotnet publish carbon-aware-sdk/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj -c Release -o publish
 # Generate OpenAPI spec
 WORKDIR carbon-aware-sdk/src/CarbonAware.WebApi/src
 RUN dotnet tool restore && \
-    mkdir -p /app/publish/wwwroot/api/v1 && \
     dotnet tool run swagger tofile --output /app/publish/wwwroot/api/v1/swagger.yaml --yaml /app/publish/CarbonAware.WebApi.dll v1
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 COPY --from=build-env /app/publish .
 ENTRYPOINT ["dotnet", "CarbonAware.WebApi.dll"]


### PR DESCRIPTION
Resolves #67

Using Carbon Aware SDK v1.7.0 requires the following:

- Use .NET 8.0 as base image for building the server container image
- Location source file configuration name change
- WattTime API base URL change to use v3.